### PR TITLE
Update TestAccDataSourceDnsRecordSet_basic to compare muxed provider with v4.50.0

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_dns_record_set_test.go.erb
@@ -3,31 +3,38 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDnsRecordSet_basic(t *testing.T) {
 	t.Parallel()
 
+	var ttl1, ttl2 string // ttl is a computed string-type attribute that is easy to compare in the test
+
 	vcrTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
-			"google": func() (tfprotov5.ProviderServer, error) {
-				provider, err := MuxedProviders(t.Name())
-				return provider(), err
-			},
-		},
 		// CheckDestroy: testAccCheckDnsRecordSetDestroyProducerFramework(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDnsRecordSet_basic(randString(t, 10), randString(t, 10)),
+				ExternalProviders: providerVersion450(),
+				Config:            testAccDataSourceDnsRecordSet_basic(randString(t, 10), randString(t, 10)),
 				Check: resource.ComposeTestCheckFunc(
 					checkDataSourceStateMatchesResourceState("data.google_dns_record_set.rs", "google_dns_record_set.rs"),
+					testExtractResourceAttr("data.google_dns_record_set.rs", "ttl", &ttl1),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: protoV5ProviderFactories(t),
+				Config:                   testAccDataSourceDnsRecordSet_basic(randString(t, 10), randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_dns_record_set.rs", "google_dns_record_set.rs"),
+					testExtractResourceAttr("data.google_dns_record_set.rs", "ttl", &ttl2),
+					testCheckAttributeValuesEqual(&ttl1, &ttl2),
 				),
 			},
 		},
@@ -37,7 +44,7 @@ func TestAccDataSourceDnsRecordSet_basic(t *testing.T) {
 func testAccDataSourceDnsRecordSet_basic(zoneName, recordSetName string) string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "zone" {
-  name     = "test-zone"
+  name     = "tf-test-zone"
   dns_name = "%s.hashicorptest.com."
 }
 

--- a/mmv1/third_party/terraform/utils/test_utils.go
+++ b/mmv1/third_party/terraform/utils/test_utils.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -154,5 +157,69 @@ func checkDataSourceStateMatchesResourceStateWithIgnores(dataSourceName, resourc
 		}
 
 		return nil
+	}
+}
+
+// testExtractResourceAttr navigates a test's state to find the specified resource (or data source) attribute and makes the value
+// accessible via the attributeValue string pointer.
+func testExtractResourceAttr(resourceName string, attributeName string, attributeValue *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName] // To find a datasource, include `data.` at the start of the resourceName value
+
+		if !ok {
+			return fmt.Errorf("resource name %s not found in state", resourceName)
+		}
+
+		attrValue, ok := rs.Primary.Attributes[attributeName]
+
+		if !ok {
+			return fmt.Errorf("attribute %s not found in resource %s state", attributeName, resourceName)
+		}
+
+		*attributeValue = attrValue
+
+		return nil
+	}
+}
+
+// testCheckAttributeValuesEqual compares two string pointers, which have been used to retrieve attribute values from the test's state.
+func testCheckAttributeValuesEqual(i *string, j *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if testStringValue(i) != testStringValue(j) {
+			return fmt.Errorf("attribute values are different, got %s and %s", testStringValue(i), testStringValue(j))
+		}
+
+		return nil
+	}
+}
+
+// testStringValue returns string values from string pointers, handling nil pointers.
+func testStringValue(sPtr *string) string {
+	if sPtr == nil {
+		return ""
+	}
+
+	return *sPtr
+}
+
+// protoV5ProviderFactories returns a muxed ProviderServer that uses the provider code from this repo (SDK and plugin-framework).
+// Used to set ProtoV5ProviderFactories in a resource.TestStep within an acceptance test.
+func protoV5ProviderFactories(t *testing.T) map[string]func() (tfprotov5.ProviderServer, error) {
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		"google": func() (tfprotov5.ProviderServer, error) {
+			provider, err := MuxedProviders(t.Name())
+			return provider(), err
+		},
+	}
+}
+
+// providerVersion450 returns information allowing tests to download TPG v4.50.0 from the Registry during `init`
+// Used to set ExternalProviders in a resource.TestStep within an acceptance test.
+func providerVersion450() map[string]resource.ExternalProvider {
+	return map[string]resource.ExternalProvider{
+		"random": {
+			VersionConstraint: "4.50.0",
+			Source:            "hashicorp/google",
+		},
 	}
 }

--- a/mmv1/third_party/terraform/utils/test_utils.go
+++ b/mmv1/third_party/terraform/utils/test_utils.go
@@ -217,7 +217,7 @@ func protoV5ProviderFactories(t *testing.T) map[string]func() (tfprotov5.Provide
 // Used to set ExternalProviders in a resource.TestStep within an acceptance test.
 func providerVersion450() map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
-		"random": {
+		"google": {
 			VersionConstraint: "4.50.0",
 			Source:            "hashicorp/google",
 		},


### PR DESCRIPTION
This PR:
- Adds use of `ExternalProviders` in TestAccDataSourceDnsRecordSet_basic to make a test step that uses a previous SDK-only version of the provider
- Adds test utils taken from the [terraform-provider-random](https://github.com/hashicorp/terraform-provider-random/blob/main/internal/provider/resource_integer_test.go#L1006) that allows state to be pulled from one test step and used in another.